### PR TITLE
Add option to specify gmsh format

### DIFF
--- a/qmesh3/mesh/mesh.py
+++ b/qmesh3/mesh/mesh.py
@@ -842,7 +842,7 @@ class Domain(object):
 
         return gmshGeometry
 
-    def gmsh(self, geoFilename=None, fldFilename=None, mshFilename=None, gmshAlgo='del2d', isMshFileBinary=False, verbosityLevel=None):
+    def gmsh(self, geoFilename=None, fldFilename=None, mshFilename=None, gmshAlgo='del2d', isMshFileBinary=False, gmshFormat='msh2', verbosityLevel=None):
         '''Generate mesh using gmsh with specified options
         '''
         import subprocess
@@ -867,6 +867,9 @@ class Domain(object):
             gmshCommand.append(str(verbosityLevel))
         if isMshFileBinary:
             gmshCommand.append('-bin')
+        if gmshFormat is not None:
+            gmshCommand.append('-format')
+            gmshCommand.append(gmshFormat)
         gmshCommand.extend([geoFilename,'-o',mshFilename])
         # Invoke gmsh command
         LOG.info('Meshing with gmsh')


### PR DESCRIPTION
Defaults to "msh2" as that's what is currently supported when reading back in. Alternative is a default of None (do not specify, i.e. use the default of the installed gmsh version) if we don't want to change behaviour for people that don't care about reading back in.